### PR TITLE
Add optional frontmatter metadata in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ arxiv2md 2501.11120v1 --section-filter-mode include --sections "Abstract,Introdu
 
 # Remove references and TOC
 arxiv2md 2501.11120v1 --remove-refs --remove-toc -o -
+
+# Include YAML frontmatter with paper metadata
+arxiv2md 2501.11120v1 --frontmatter -o paper.md
 ```
 
 ### API
@@ -81,6 +84,7 @@ curl "https://arxiv2md.org/api/markdown?url=2312.00752"
 | `remove_refs` | `true` | Remove references |
 | `remove_toc` | `true` | Remove table of contents |
 | `remove_citations` | `true` | Remove inline citations |
+| `frontmatter` | `false` | Prepend YAML frontmatter with paper metadata (`/api/markdown` only) |
 
 **Rate limit:** 30 requests/minute per IP.
 

--- a/src/arxiv2md/__main__.py
+++ b/src/arxiv2md/__main__.py
@@ -44,6 +44,7 @@ async def _async_main(args: argparse.Namespace) -> None:
         remove_inline_citations=args.remove_inline_citations,
         section_filter_mode=args.section_filter_mode,
         sections=sections,
+        include_frontmatter=args.frontmatter,
     )
 
     output_text = _format_output(
@@ -51,6 +52,7 @@ async def _async_main(args: argparse.Namespace) -> None:
         result.sections_tree,
         result.content,
         include_tree=args.include_tree,
+        frontmatter=result.frontmatter,
     )
     output_target = args.output if args.output is not None else DEFAULT_OUTPUT_FILE
 
@@ -66,10 +68,23 @@ async def _async_main(args: argparse.Namespace) -> None:
         print(result.summary)
 
 
-def _format_output(summary: str, tree: str, content: str, *, include_tree: bool) -> str:
+def _format_output(
+    summary: str,
+    tree: str,
+    content: str,
+    *,
+    include_tree: bool,
+    frontmatter: str | None = None,
+) -> str:
+    parts: list[str] = []
+    if frontmatter:
+        parts.append(frontmatter)
+    else:
+        parts.append(summary)
     if include_tree:
-        return f"{summary}\n\n{tree}\n\n{content}".strip()
-    return f"{summary}\n\n{content}".strip()
+        parts.append(tree)
+    parts.append(content)
+    return "\n\n".join(parts).strip()
 
 
 def _collect_sections(sections_csv: str | None, section_list: list[str] | None) -> list[str]:
@@ -131,6 +146,11 @@ def _parse_args() -> argparse.Namespace:
         "--include-tree",
         action="store_true",
         help="Include the section tree before the Markdown content.",
+    )
+    parser.add_argument(
+        "--frontmatter",
+        action="store_true",
+        help="Prepend YAML frontmatter with paper metadata (title, authors, URL, etc.).",
     )
     return parser.parse_args()
 

--- a/src/arxiv2md/ingestion.py
+++ b/src/arxiv2md/ingestion.py
@@ -24,6 +24,7 @@ async def ingest_paper(
     remove_inline_citations: bool = False,
     section_filter_mode: str,
     sections: list[str],
+    include_frontmatter: bool = False,
 ) -> tuple[IngestionResult, dict[str, str | list[str] | None]]:
     """Fetch, parse, and serialize an arXiv paper into Markdown.
 
@@ -59,6 +60,7 @@ async def ingest_paper(
         sections=filtered_sections,
         include_toc=not remove_toc,
         include_abstract_in_tree=parsed.abstract is not None,
+        include_frontmatter=include_frontmatter,
     )
 
     metadata = {

--- a/src/arxiv2md/output_formatter.py
+++ b/src/arxiv2md/output_formatter.py
@@ -12,6 +12,9 @@ except ImportError:  # pragma: no cover - optional dependency
 from arxiv2md.schemas import IngestionResult, SectionNode
 
 
+_ARXIV_ABS_BASE = "https://arxiv.org/abs/"
+
+
 def format_paper(
     *,
     arxiv_id: str,
@@ -22,6 +25,7 @@ def format_paper(
     sections: list[SectionNode],
     include_toc: bool,
     include_abstract_in_tree: bool = True,
+    include_frontmatter: bool = False,
 ) -> IngestionResult:
     """Create summary, section tree, and content."""
     tree_lines = ["Sections:"]
@@ -31,6 +35,9 @@ def format_paper(
     tree = "\n".join(tree_lines)
     content = _render_content(abstract=abstract, sections=sections, include_toc=include_toc)
 
+    section_count = count_sections(sections)
+    token_estimate = _format_token_count(tree + "\n" + content)
+
     summary_lines = []
     if title:
         summary_lines.append(f"Title: {title}")
@@ -39,15 +46,55 @@ def format_paper(
         summary_lines.append(f"Version: {version}")
     if authors:
         summary_lines.append(f"Authors: {', '.join(authors)}")
-    summary_lines.append(f"Sections: {count_sections(sections)}")
-
-    token_estimate = _format_token_count(tree + "\n" + content)
+    summary_lines.append(f"Sections: {section_count}")
     if token_estimate:
         summary_lines.append(f"Estimated tokens: {token_estimate}")
 
     summary = "\n".join(summary_lines)
 
-    return IngestionResult(summary=summary, sections_tree=tree, content=content)
+    frontmatter = None
+    if include_frontmatter:
+        frontmatter = _generate_frontmatter(
+            title=title,
+            arxiv_id=arxiv_id,
+            version=version,
+            authors=authors,
+            section_count=section_count,
+            token_estimate=token_estimate,
+        )
+
+    return IngestionResult(summary=summary, sections_tree=tree, content=content, frontmatter=frontmatter)
+
+
+def _generate_frontmatter(
+    *,
+    title: str | None,
+    arxiv_id: str,
+    version: str | None,
+    authors: list[str],
+    section_count: int,
+    token_estimate: str | None,
+) -> str:
+    """Generate YAML frontmatter block with paper metadata."""
+    lines = ["---"]
+    if title:
+        lines.append(f"title: \"{_escape_yaml_string(title)}\"")
+    if version:
+        lines.append(f"version: \"{version}\"")
+    if authors:
+        quoted = ", ".join(f'"{_escape_yaml_string(a)}"' for a in authors)
+        lines.append(f"authors: [{quoted}]")
+    lines.append(f"url: \"{_ARXIV_ABS_BASE}{arxiv_id}\"")
+    lines.append(f"sections: {section_count}")
+    if token_estimate:
+        lines.append(f"estimated_tokens: \"{token_estimate}\"")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _escape_yaml_string(value: str) -> str:
+    """Escape characters that are special in YAML string values."""
+    return value.replace("\\", "\\\\").replace("\"", "\\\"")
 
 
 def count_sections(sections: Iterable[SectionNode]) -> int:

--- a/src/arxiv2md/schemas/ingestion.py
+++ b/src/arxiv2md/schemas/ingestion.py
@@ -11,3 +11,4 @@ class IngestionResult(BaseModel):
     summary: str
     sections_tree: str
     content: str
+    frontmatter: str | None = None

--- a/src/server/models.py
+++ b/src/server/models.py
@@ -36,6 +36,10 @@ class IngestRequest(BaseModel):
         default=False,
         description="Remove inline citations and internal paper links from output",
     )
+    include_frontmatter: bool = Field(
+        default=False,
+        description="Prepend YAML frontmatter with paper metadata",
+    )
     section_filter_mode: SectionFilterMode = Field(
         default=SectionFilterMode.EXCLUDE,
         description="Section filtering mode",
@@ -85,6 +89,7 @@ class IngestSuccessResponse(BaseModel):
     tree: str = Field(..., description="Section tree structure")
     sections_tree: str | None = Field(default=None, description="Section tree (alias for tree)")
     content: str = Field(..., description="Processed markdown content")
+    frontmatter: str | None = Field(default=None, description="YAML frontmatter block with paper metadata")
     remove_refs: bool | None = Field(default=None)
     remove_toc: bool | None = Field(default=None)
     section_filter_mode: str | None = Field(default=None)

--- a/src/server/query_processor.py
+++ b/src/server/query_processor.py
@@ -42,6 +42,7 @@ async def process_query(
     pattern_type: PatternType | None = None,
     pattern: str | None = None,
     token: str | None = None,
+    include_frontmatter: bool = False,
 ) -> IngestResponse:
     """Process an arXiv query and return a markdown summary."""
     # These parameters are kept for API compatibility but not used
@@ -77,6 +78,7 @@ async def process_query(
             remove_inline_citations=query.remove_inline_citations,
             section_filter_mode=query.section_filter_mode,
             sections=query.sections,
+            include_frontmatter=include_frontmatter,
         )
         summary = result.summary
         tree = result.sections_tree
@@ -106,6 +108,7 @@ async def process_query(
         tree=tree,
         sections_tree=tree,
         content=content,
+        frontmatter=result.frontmatter,
         remove_refs=remove_refs,
         remove_toc=remove_toc,
         section_filter_mode=section_filter_mode,

--- a/src/server/routers/ingest.py
+++ b/src/server/routers/ingest.py
@@ -43,6 +43,7 @@ async def api_ingest(
         remove_refs=ingest_request.remove_refs,
         remove_toc=ingest_request.remove_toc,
         remove_inline_citations=ingest_request.remove_inline_citations,
+        include_frontmatter=ingest_request.include_frontmatter,
         section_filter_mode=ingest_request.section_filter_mode.value,
         sections=ingest_request.sections,
     )

--- a/src/server/routers/markdown_api.py
+++ b/src/server/routers/markdown_api.py
@@ -84,6 +84,7 @@ async def api_markdown(
     remove_refs: bool = Query(default=True, description="Remove references section"),
     remove_toc: bool = Query(default=True, description="Remove table of contents"),
     remove_citations: bool = Query(default=True, description="Remove inline citations"),
+    frontmatter: bool = Query(default=False, description="Prepend YAML frontmatter with paper metadata"),
 ) -> PlainTextResponse:
     """Convert an arXiv paper to markdown and return raw markdown text.
 
@@ -102,6 +103,7 @@ async def api_markdown(
             remove_inline_citations=remove_citations,
             section_filter_mode="exclude",
             sections=[],
+            include_frontmatter=frontmatter,
         )
 
         if isinstance(result, IngestErrorResponse):
@@ -110,7 +112,10 @@ async def api_markdown(
                 content=f"Error: {result.error}",
             )
 
-        return PlainTextResponse(status_code=status.HTTP_200_OK, content=result.content)
+        md_content = result.content
+        if result.frontmatter:
+            md_content = result.frontmatter + "\n\n" + md_content
+        return PlainTextResponse(status_code=status.HTTP_200_OK, content=md_content)
 
     except ValueError as ve:
         return PlainTextResponse(status_code=status.HTTP_400_BAD_REQUEST, content=f"Validation error: {ve!s}")

--- a/src/server/routers_utils.py
+++ b/src/server/routers_utils.py
@@ -26,6 +26,7 @@ async def _perform_ingestion(
     remove_refs: bool,
     remove_toc: bool,
     remove_inline_citations: bool = False,
+    include_frontmatter: bool = False,
     section_filter_mode: str = "exclude",
     sections: list[str] | None = None,
 ) -> JSONResponse:
@@ -48,6 +49,7 @@ async def _perform_ingestion(
             remove_refs=remove_refs,
             remove_toc=remove_toc,
             remove_inline_citations=remove_inline_citations,
+            include_frontmatter=include_frontmatter,
             section_filter_mode=section_filter_mode,
             sections=sections or [],
         )

--- a/src/server/templates/components/arxiv_form.jinja
+++ b/src/server/templates/components/arxiv_form.jinja
@@ -63,6 +63,17 @@
                 </div>
                 <!-- Output toggles -->
                 <div class="flex flex-col gap-4 justify-center">
+                    <label for="include_frontmatter" class="flex items-center gap-3 text-gray-900 cursor-pointer hover:text-[#B31B1B] transition-colors">
+                        <span class="relative w-6 h-6">
+                            <input type="checkbox"
+                                   id="include_frontmatter"
+                                   name="include_frontmatter"
+                                   class="cursor-pointer peer appearance-none w-full h-full rounded-sm border-[3px] border-current bg-white m-0 text-current shadow-[3px_3px_0_currentColor]" />
+                            <span class="absolute inset-0 w-3 h-3 m-auto scale-0 transition-transform duration-150 ease-in-out shadow-[inset_1rem_1rem_#B31B1B] bg-[CanvasText] origin-bottom-left peer-checked:scale-100"
+                                  style="clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%)"></span>
+                        </span>
+                        Include YAML frontmatter
+                    </label>
                     <label for="remove_refs" class="flex items-center gap-3 text-gray-900 cursor-pointer hover:text-[#B31B1B] transition-colors">
                         <span class="relative w-6 h-6">
                             <input type="checkbox"

--- a/src/static/js/utils.js
+++ b/src/static/js/utils.js
@@ -138,6 +138,7 @@ function collectFormData(form) {
     const removeRefs = form.querySelector('[name="remove_refs"]');
     const removeToc = form.querySelector('[name="remove_toc"]');
     const removeInlineCitations = form.querySelector('[name="remove_inline_citations"]');
+    const includeFrontmatter = form.querySelector('[name="include_frontmatter"]');
     const sectionFilterMode = form.querySelector('[name="section_filter_mode"]');
     const sectionsInput = form.querySelector('[name="sections"]');
 
@@ -149,6 +150,7 @@ function collectFormData(form) {
     if (removeRefs) {json_data.remove_refs = removeRefs.checked;}
     if (removeToc) {json_data.remove_toc = removeToc.checked;}
     if (removeInlineCitations) {json_data.remove_inline_citations = removeInlineCitations.checked;}
+    if (includeFrontmatter) {json_data.include_frontmatter = includeFrontmatter.checked;}
     if (sectionFilterMode) {json_data.section_filter_mode = sectionFilterMode.value;}
     if (sectionsInput) {
         json_data.sections = sectionsInput.value
@@ -199,7 +201,8 @@ function handleSuccessfulResponse(data) {
     // Set plain text content for summary, tree, and content
     document.getElementById('result-summary').value = data.summary || '';
     document.getElementById('directory-structure-content').value = data.tree || '';
-    document.getElementById('result-content').value = data.content || '';
+    const content = data.frontmatter ? data.frontmatter + '\n\n' + (data.content || '') : (data.content || '');
+    document.getElementById('result-content').value = content;
 
     // Populate directory structure lines as clickable <pre> elements
     const dirPre = document.getElementById('directory-structure-pre');

--- a/tests/test_output_formatter.py
+++ b/tests/test_output_formatter.py
@@ -1,0 +1,135 @@
+"""Tests for output formatting, including frontmatter generation."""
+
+from __future__ import annotations
+
+from arxiv2md.output_formatter import format_paper
+from arxiv2md.schemas import SectionNode
+
+
+def _make_sections() -> list[SectionNode]:
+    """Create a minimal section tree for testing."""
+    child = SectionNode(title="1.1 Background", level=3, html="<p>Background info.</p>")
+    return [
+        SectionNode(title="1 Introduction", level=2, html="<p>Intro text.</p>", children=[child]),
+        SectionNode(title="2 Methods", level=2, html="<p>Methods text.</p>"),
+    ]
+
+
+def test_frontmatter_disabled_by_default() -> None:
+    result = format_paper(
+        arxiv_id="2501.11120v1",
+        version="v1",
+        title="Test Paper",
+        authors=["Alice", "Bob"],
+        abstract="Abstract text.",
+        sections=_make_sections(),
+        include_toc=False,
+    )
+    assert result.frontmatter is None
+
+
+def test_frontmatter_contains_all_fields() -> None:
+    result = format_paper(
+        arxiv_id="2501.11120v1",
+        version="v1",
+        title="Test Paper",
+        authors=["Alice", "Bob"],
+        abstract="Abstract text.",
+        sections=_make_sections(),
+        include_toc=False,
+        include_frontmatter=True,
+    )
+    assert result.frontmatter is not None
+    assert result.frontmatter.startswith("---")
+    assert result.frontmatter.endswith("---")
+    assert 'title: "Test Paper"' in result.frontmatter
+    assert 'version: "v1"' in result.frontmatter
+    assert 'authors: ["Alice", "Bob"]' in result.frontmatter
+    assert 'url: "https://arxiv.org/abs/2501.11120v1"' in result.frontmatter
+    assert "sections: 3" in result.frontmatter
+
+
+def test_frontmatter_omits_version_when_none() -> None:
+    result = format_paper(
+        arxiv_id="2501.11120",
+        version=None,
+        title="Test Paper",
+        authors=["Alice"],
+        abstract="Abstract text.",
+        sections=_make_sections(),
+        include_toc=False,
+        include_frontmatter=True,
+    )
+    assert result.frontmatter is not None
+    assert "version:" not in result.frontmatter
+    assert 'url: "https://arxiv.org/abs/2501.11120"' in result.frontmatter
+
+
+def test_frontmatter_omits_title_when_none() -> None:
+    result = format_paper(
+        arxiv_id="2501.11120",
+        version=None,
+        title=None,
+        authors=["Alice"],
+        abstract=None,
+        sections=_make_sections(),
+        include_toc=False,
+        include_frontmatter=True,
+    )
+    assert result.frontmatter is not None
+    assert "title:" not in result.frontmatter
+
+
+def test_frontmatter_omits_authors_when_empty() -> None:
+    result = format_paper(
+        arxiv_id="2501.11120",
+        version=None,
+        title="Test",
+        authors=[],
+        abstract=None,
+        sections=_make_sections(),
+        include_toc=False,
+        include_frontmatter=True,
+    )
+    assert result.frontmatter is not None
+    assert "authors:" not in result.frontmatter
+
+
+def test_frontmatter_escapes_special_yaml_chars_in_title() -> None:
+    result = format_paper(
+        arxiv_id="2501.11120",
+        version=None,
+        title='A "Quoted" Title: With Colons',
+        authors=["Alice"],
+        abstract=None,
+        sections=_make_sections(),
+        include_toc=False,
+        include_frontmatter=True,
+    )
+    assert result.frontmatter is not None
+    assert r'title: "A \"Quoted\" Title: With Colons"' in result.frontmatter
+
+
+def test_frontmatter_does_not_affect_summary() -> None:
+    result_with = format_paper(
+        arxiv_id="2501.11120v1",
+        version="v1",
+        title="Test Paper",
+        authors=["Alice"],
+        abstract="Abstract text.",
+        sections=_make_sections(),
+        include_toc=False,
+        include_frontmatter=True,
+    )
+    result_without = format_paper(
+        arxiv_id="2501.11120v1",
+        version="v1",
+        title="Test Paper",
+        authors=["Alice"],
+        abstract="Abstract text.",
+        sections=_make_sections(),
+        include_toc=False,
+        include_frontmatter=False,
+    )
+    assert result_with.summary == result_without.summary
+    assert result_with.content == result_without.content


### PR DESCRIPTION
Hey, first off, thanks for making this project!
Was just about to make my own from scratch, and then found this amazing project :)

This PR adds an opt-in `--frontmatter` flag that prepends YAML frontmatter with paper metadata to the markdown output. Available across CLI, API, and the web UI.

Example output:
```yaml
---
title: "Tell me about yourself: LLMs are aware of their learned behaviors"
version: "v1"
authors: ["Jan Betley", "Xuchan Bao", "Martín Soto", "Anna Sztyber-Betley", "James Chua", "Owain Evans"]
url: "https://arxiv.org/abs/2501.11120v1"
sections: 95
estimated_tokens: "50.6k"
---
```

This is useful when using your project as a tool for AI agents that allows them to fetch specific research papers.

With this metadata, agents now have additional context with metadata on the research paper (like its source URL, authors, and title), and with proper instructions, they can just read the top 10–20 lines to have an estimation of how long this paper is, and how many tokens it would consume.

## Screenshots

<img src="https://github.com/user-attachments/assets/b16b277c-0b70-479c-b568-c82e12e33176" />
<img src="https://github.com/user-attachments/assets/8d20cc5f-439f-4f88-b746-69c3f5d5dea6" />
