### PR TITLE
feat: add --include-images flag to emit markdown image links

### DIFF
--- a/src/arxiv2md/__main__.py
+++ b/src/arxiv2md/__main__.py
@@ -37,6 +37,8 @@ async def _async_main(args: argparse.Namespace) -> None:
         remove_refs=args.remove_refs,
         remove_toc=args.remove_toc,
         remove_inline_citations=args.remove_inline_citations,
+        include_images=args.include_images,
+        html_base_url=query.html_url,
         section_filter_mode=args.section_filter_mode,
         sections=sections,
     )
@@ -125,6 +127,11 @@ def _parse_args() -> argparse.Namespace:
         "-o",
         default=None,
         help="Output file path. Use '-' to write to stdout.",
+    )
+    parser.add_argument(
+        "--include-images",
+        action="store_true",
+        help="Emit proper markdown image syntax with absolute arXiv URLs instead of plain text.",
     )
     parser.add_argument(
         "--include-tree",

--- a/src/arxiv2md/ingestion.py
+++ b/src/arxiv2md/ingestion.py
@@ -22,6 +22,8 @@ async def ingest_paper(
     remove_refs: bool,
     remove_toc: bool,
     remove_inline_citations: bool = False,
+    include_images: bool = False,
+    html_base_url: str | None = None,
     section_filter_mode: str,
     sections: list[str],
 ) -> tuple[IngestionResult, dict[str, str | list[str] | None]]:
@@ -48,7 +50,8 @@ async def ingest_paper(
         include_abstract = not sections or _ABSTRACT_TITLE in selected_lower
 
     for section in filtered_sections:
-        _populate_section_markdown(section, remove_inline_citations=remove_inline_citations)
+        image_base_url = f"{html_base_url.rstrip('/')}/" if include_images and html_base_url else None
+        _populate_section_markdown(section, remove_inline_citations=remove_inline_citations, image_base_url=image_base_url)
 
     result = format_paper(
         arxiv_id=arxiv_id,
@@ -70,8 +73,8 @@ async def ingest_paper(
     return result, metadata
 
 
-def _populate_section_markdown(section, *, remove_inline_citations: bool = False) -> None:
+def _populate_section_markdown(section, *, remove_inline_citations: bool = False, image_base_url: str | None = None) -> None:
     if section.html:
-        section.markdown = convert_fragment_to_markdown(section.html, remove_inline_citations=remove_inline_citations)
+        section.markdown = convert_fragment_to_markdown(section.html, remove_inline_citations=remove_inline_citations, image_base_url=image_base_url)
     for child in section.children:
-        _populate_section_markdown(child, remove_inline_citations=remove_inline_citations)
+        _populate_section_markdown(child, remove_inline_citations=remove_inline_citations, image_base_url=image_base_url)

--- a/src/arxiv2md/markdown.py
+++ b/src/arxiv2md/markdown.py
@@ -57,7 +57,7 @@ def convert_html_to_markdown(html: str, *, remove_refs: bool = False, remove_toc
     return "\n\n".join(block for block in blocks if block).strip()
 
 
-def convert_fragment_to_markdown(html: str, *, remove_inline_citations: bool = False) -> str:
+def convert_fragment_to_markdown(html: str, *, remove_inline_citations: bool = False, image_base_url: str | None = None) -> str:
     """Convert an HTML fragment into Markdown without title/author/abstract handling.
 
     Parameters
@@ -72,7 +72,7 @@ def convert_fragment_to_markdown(html: str, *, remove_inline_citations: bool = F
     _strip_unwanted_elements(soup)
     convert_all_mathml_to_latex(soup)
     fix_tabular_tables(soup)
-    blocks = _serialize_children(soup, remove_inline_citations=remove_inline_citations)
+    blocks = _serialize_children(soup, remove_inline_citations=remove_inline_citations, image_base_url=image_base_url)
     return "\n\n".join(block for block in blocks if block).strip()
 
 
@@ -119,20 +119,20 @@ def _remove_all_attributes(tag: Tag) -> None:
     tag.attrs = {}
 
 
-def _serialize_children(container: Tag, *, remove_inline_citations: bool = False) -> list[str]:
+def _serialize_children(container: Tag, *, remove_inline_citations: bool = False, image_base_url: str | None = None) -> list[str]:
     blocks: list[str] = []
     for child in container.children:
         if isinstance(child, NavigableString):
             continue
         if not isinstance(child, Tag):
             continue
-        blocks.extend(_serialize_block(child, remove_inline_citations=remove_inline_citations))
+        blocks.extend(_serialize_block(child, remove_inline_citations=remove_inline_citations, image_base_url=image_base_url))
     return blocks
 
 
-def _serialize_block(tag: Tag, *, remove_inline_citations: bool = False) -> list[str]:
+def _serialize_block(tag: Tag, *, remove_inline_citations: bool = False, image_base_url: str | None = None) -> list[str]:
     if tag.name in {"section", "article", "div", "span"}:
-        return _serialize_children(tag, remove_inline_citations=remove_inline_citations)
+        return _serialize_children(tag, remove_inline_citations=remove_inline_citations, image_base_url=image_base_url)
 
     if tag.name in {"h1", "h2", "h3", "h4", "h5", "h6"}:
         level = int(tag.name[1])
@@ -150,7 +150,7 @@ def _serialize_block(tag: Tag, *, remove_inline_citations: bool = False) -> list
         return ["\n".join(lines)] if lines else []
 
     if tag.name == "figure":
-        figure = _serialize_figure(tag, remove_inline_citations=remove_inline_citations)
+        figure = _serialize_figure(tag, remove_inline_citations=remove_inline_citations, image_base_url=image_base_url)
         return [figure] if figure else []
 
     if tag.name == "table":
@@ -166,7 +166,7 @@ def _serialize_block(tag: Tag, *, remove_inline_citations: bool = False) -> list
     if tag.name == "br":
         return []
 
-    return _serialize_children(tag, remove_inline_citations=remove_inline_citations)
+    return _serialize_children(tag, remove_inline_citations=remove_inline_citations, image_base_url=image_base_url)
 
 
 def _serialize_abstract(tag: Tag) -> list[str]:
@@ -340,7 +340,7 @@ def _serialize_table(table: Tag, *, remove_inline_citations: bool = False) -> st
     return "\n".join(lines)
 
 
-def _serialize_figure(figure: Tag, *, remove_inline_citations: bool = False) -> str:
+def _serialize_figure(figure: Tag, *, remove_inline_citations: bool = False, image_base_url: str | None = None) -> str:
     # Check if this is a table figure (ltx_table class)
     figure_classes = " ".join(figure.get("class", []))
     is_table_figure = "ltx_table" in figure_classes
@@ -373,7 +373,16 @@ def _serialize_figure(figure: Tag, *, remove_inline_citations: bool = False) -> 
             lines.append(f"Figure: {caption}")
         if src:
             image_label = alt or "Image"
-            lines.append(f"{image_label}: {src}")
+            if image_base_url:
+                if src.startswith(("http://", "https://")):
+                    full_url = src
+                elif src.startswith("/"):
+                    full_url = f"https://arxiv.org{src}"
+                else:
+                    full_url = f"{image_base_url}{src}"
+                lines.append(f"![{image_label}]({full_url})")
+            else:
+                lines.append(f"{image_label}: {src}")
 
     return "\n".join(lines).strip()
 


### PR DESCRIPTION
## Summary
- Adds `--include-images` CLI flag that emits proper markdown image syntax (`![alt](https://arxiv.org/html/...)`) instead of plain text (`Image: /path`)
- Flag is off by default — no behavior change for existing users
- Threads the parameter through `ingest_paper()` → `convert_fragment_to_markdown()` → `_serialize_figure()`

## Test plan
- [x] All 10 existing tests pass (`pytest tests/`)
- [x] Manual: `python -m arxiv2md 2501.11120v1 --include-images -o - | grep '!\['` — verify markdown image links appear
- [x] Manual: `python -m arxiv2md 2501.11120v1 -o - | grep -E 'Image:|Figure:'` — verify default behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)